### PR TITLE
Change tomcat to alpine image to fix the build for apple silicon

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ COPY ./pom.xml ./pom.xml
 COPY ./src ./src
 RUN mvn clean package
 
-FROM tomcat:8.0
+FROM tomcat:8.0-alpine
 COPY --from=builder /target/EShop-1.0.0.war /usr/local/tomcat/webapps/
 COPY ./conf/tomcat-users.xml /usr/local/tomcat/conf/tomcat-users.xml
 


### PR DESCRIPTION
I had issues building the tomcat container on apple silicon, switching to the alpine image fixed that, since it properly supports the ARM architecture, maybe this is helpful for others.

<img width="1266" alt="image" src="https://user-images.githubusercontent.com/28872997/138265063-3d9e7bae-c1ad-45c7-9a47-75b4d41d294f.png">
